### PR TITLE
Mark styleString as htmlSafe to remove deprecations in Ember 1.11+.

### DIFF
--- a/addon/mixins/style-bindings-mixin.js
+++ b/addon/mixins/style-bindings-mixin.js
@@ -41,7 +41,7 @@ export default Ember.Mixin.create({
       });
       styleString = styleTokens.join('');
       if (styleString.length !== 0) {
-        return styleString;
+        return styleString.htmlSafe();
       }
     });
     styleComputed.property.apply(styleComputed, properties);


### PR DESCRIPTION
This was throwing quite a few deprecation warnings (one per row).