### PR TITLE
Don't re-register the library if already registered.

### DIFF
--- a/app/initializers/ember-cli-ember-table.js
+++ b/app/initializers/ember-cli-ember-table.js
@@ -1,12 +1,16 @@
 /* global jQuery */
 
+import Ember from 'ember';
+var registered = false;
+
 export default {
   name: 'ember-cli-ember-table',
-  initialize: function(container, app) {
+  initialize: function() {
 
     var VERSION = '0.2.2';
-    if (Ember.libraries !== null) {
+    if (!registered) {
       Ember.libraries.register('Ember Table', VERSION);
+      registered = true;
     }
 
     /*


### PR DESCRIPTION
Removes 'Library "Ember Table" is already registered with Ember' deprecations in tests. We are also guaranteed `Ember.libraries` is present, so the null check can be avoided.