### PR TITLE
Add 0.1.1 to package.json, fix bug in resize code.

### DIFF
--- a/addon/resize-detection.js
+++ b/addon/resize-detection.js
@@ -20,7 +20,8 @@ function resizeListener(e) {
   }
   win.__resizeRAF__ = requestFrame(function(){
     var trigger = win.__resizeTrigger__;
-    trigger.__resizeListeners__.forEach(function(fn){
+    if (!trigger) { return; }
+    (trigger.__resizeListeners__ || []).forEach(function(fn){
       fn.call(trigger, e);
     });
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-ember-table",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "directories": {
     "doc": "doc",
     "test": "tests"


### PR DESCRIPTION
This library is on 0.1.1, so the package.json should reflect this.

Additionally, prevents a random phantomjs error where sometimes `trigger.__resizeListeners__` was `undefined` instead of `[]`.

Let me know if you'd like me to split this to 2 PR's.